### PR TITLE
Add RLM template

### DIFF
--- a/bin/rlm-util.py
+++ b/bin/rlm-util.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""
+File that will be called by the license-manager-agent in the report function.
+
+It will hit the /licenses-in-use/ endpoint and will generate the report in the same format as the rlm,
+this way we can use the same rlm parser in the license-manager-agent.
+"""
+import requests
+from jinja2 import Environment, FileSystemLoader
+
+# You must modify this value to reflect the ip address and port that the
+# license-manager-simulator is listening on in your environment.
+#
+# The format of the value is: `http://<ip-address>:<port>`
+URL = "http://localhost:8000"
+
+
+def get_server_data():
+    license = requests.get(URL + "/licenses/").json()[0]
+    return {
+        "license_name": license.get("name"),
+        "total_licenses": license.get("total"),
+        "in_use": license.get("in_use"),
+        "licenses_in_use": license.get("licenses_in_use"),
+    }
+
+
+def generate_license_server_output() -> None:
+    """Print output formatted to stdout."""
+    source = "rlm.out.tmpl"
+    license_information = get_server_data()
+
+    template = Environment(loader=FileSystemLoader(".")).get_template(source)
+    print(template.render(**license_information))
+
+
+if __name__ == "__main__":
+    generate_license_server_output()

--- a/bin/rlm-util.py
+++ b/bin/rlm-util.py
@@ -16,22 +16,35 @@ URL = "http://localhost:8000"
 
 
 def get_server_data():
-    license = requests.get(URL + "/licenses/").json()[0]
-    return {
-        "license_name": license.get("name"),
-        "total_licenses": license.get("total"),
-        "in_use": license.get("in_use"),
-        "licenses_in_use": license.get("licenses_in_use"),
-    }
+    licenses = requests.get(URL + "/licenses/").json()
+
+    licenses_information = []
+    any_in_use = False
+
+    for license in licenses:
+        licenses_information.append(
+            {
+                "license_name": license.get("name"),
+                "total_licenses": license.get("total"),
+                "in_use": license.get("in_use"),
+                "licenses_in_use": license.get("licenses_in_use"),
+            }
+        )
+        if license.get("in_use") > 0:
+            any_in_use = True
+
+    return {"licenses_information": licenses_information, "any_in_use": any_in_use}
 
 
 def generate_license_server_output() -> None:
     """Print output formatted to stdout."""
     source = "rlm.out.tmpl"
-    license_information = get_server_data()
+    licenses_information = get_server_data()
 
-    template = Environment(loader=FileSystemLoader(".")).get_template(source)
-    print(template.render(**license_information))
+    template = Environment(loader=FileSystemLoader("."), trim_blocks=True, lstrip_blocks=True).get_template(
+        source
+    )
+    print(template.render(**licenses_information))
 
 
 if __name__ == "__main__":

--- a/bin/rlm.out.tmpl
+++ b/bin/rlm.out.tmpl
@@ -11,7 +11,7 @@ Copyright (C) 2006-2017, Reprise Software, Inc. All rights reserved.
 	Recent Statistics (00:16:08), init time: Wed Nov  3 12:32:30 2021
 
 	             Recent Stats         Todays Stats         Total Stats
-	              00:16:08             13:48:32         15d 11:08:25
+	              00:16:08             13:48:32             11:08:25
 	Messages:    582 (0/sec)           28937 (0/sec)          777647 (0/sec)
 	Connections: 463 (0/sec)           23147 (0/sec)          622164 (0/sec)
 
@@ -31,7 +31,7 @@ Copyright (C) 2006-2017, Reprise Software, Inc. All rights reserved.
 	Recent Statistics (00:16:08), init time: Wed Nov  3 12:32:30 2021
 
 	             Recent Stats         Todays Stats         Total Stats
-	              00:16:08             13:48:32         15d 11:08:18
+	              00:16:08             13:48:32             11:08:18
 	Messages:    691 (0/sec)           34770 (0/sec)          935961 (0/sec)
 	Connections: 345 (0/sec)           17359 (0/sec)          466699 (0/sec)
 	Checkouts:   0 (0/sec)           1 (0/sec)          237 (0/sec)

--- a/bin/rlm.out.tmpl
+++ b/bin/rlm.out.tmpl
@@ -1,0 +1,57 @@
+Setting license file path to 35015@licserv0011.com
+rlmutil v12.2
+Copyright (C) 2006-2017, Reprise Software, Inc. All rights reserved.
+
+
+	rlm status on licserv0011.com (port 35015), up 15d 11:08:25
+   	rlm software version v12.2 (build:2)
+	rlm comm version: v1.2
+	Startup time: Tue Oct 19 01:40:13 2021
+	Todays Statistics (13:48:32), init time: Tue Nov  2 23:00:06 2021
+	Recent Statistics (00:16:08), init time: Wed Nov  3 12:32:30 2021
+
+	             Recent Stats         Todays Stats         Total Stats
+	              00:16:08             13:48:32         15d 11:08:25
+	Messages:    582 (0/sec)           28937 (0/sec)          777647 (0/sec)
+	Connections: 463 (0/sec)           23147 (0/sec)          622164 (0/sec)
+
+	--------- ISV servers ----------
+	   Name           Port Running Restarts
+	csci             63133   Yes      0
+
+	------------------------
+
+	csci ISV server status on licserv0011.com (port 63133), up 15d 11:08:18
+	csci software version v12.2 (build: 2)
+	csci comm version: v1.2
+	csci Debug log filename: F:\RLM\Logs\csci.dlog
+	csci Report log filename: F:\RLM\logs\Reportlogs\CSCILOG.rl
+	Startup time: Tue Oct 19 01:40:20 2021
+	Todays Statistics (13:48:32), init time: Tue Nov  2 23:00:06 2021
+	Recent Statistics (00:16:08), init time: Wed Nov  3 12:32:30 2021
+
+	             Recent Stats         Todays Stats         Total Stats
+	              00:16:08             13:48:32         15d 11:08:18
+	Messages:    691 (0/sec)           34770 (0/sec)          935961 (0/sec)
+	Connections: 345 (0/sec)           17359 (0/sec)          466699 (0/sec)
+	Checkouts:   0 (0/sec)           1 (0/sec)          237 (0/sec)
+	Denials:     0 (0/sec)           0 (0/sec)          0 (0/sec)
+	Removals:    0 (0/sec)           0 (0/sec)          0 (0/sec)
+
+
+	------------------------
+
+	csci license pool status on licserv0011.com (port 63133)
+
+	{{license_name}} v3.0
+		count: {{total_licenses}}, # reservations: 0, inuse: {{in_use}}, exp: 31-jan-2022
+		obsolete: 0, min_remove: 120, total checkouts: 0
+
+    {% if licenses_in_use|length > 0 %}
+	------------------------
+
+	csci license usage status on licserv0011.com (port 63133)
+    {% for license_in_use in licenses_in_use %}
+	{{license_in_use.license_name}} v3.0: {{license_in_use.user_name}}@{{license_in_use.lead_host}} {{license_in_use.quantity}}/0 at 11/01 09:01  (handle: 15a)
+    {% endfor %}
+    {% endif %}

--- a/bin/rlm.out.tmpl
+++ b/bin/rlm.out.tmpl
@@ -43,15 +43,21 @@ Copyright (C) 2006-2017, Reprise Software, Inc. All rights reserved.
 
 	csci license pool status on licserv0011.com (port 63133)
 
-	{{license_name}} v3.0
-		count: {{total_licenses}}, # reservations: 0, inuse: {{in_use}}, exp: 31-jan-2022
+	{% for license in licenses_information %}
+	{{license.license_name}} v3.0
+		count: {{license.total_licenses}}, # reservations: 0, inuse: {{license.in_use}}, exp: 31-jan-2022
 		obsolete: 0, min_remove: 120, total checkouts: 0
+	{% endfor %}
+    {% if any_in_use %}
 
-    {% if licenses_in_use|length > 0 %}
+
 	------------------------
 
 	csci license usage status on licserv0011.com (port 63133)
-    {% for license_in_use in licenses_in_use %}
+
+	{% for license in licenses_information %}
+    {% for license_in_use in license.licenses_in_use %}
 	{{license_in_use.license_name}} v3.0: {{license_in_use.user_name}}@{{license_in_use.lead_host}} {{license_in_use.quantity}}/0 at 11/01 09:01  (handle: 15a)
     {% endfor %}
+	{% endfor %}
     {% endif %}


### PR DESCRIPTION
**What**
Add RLM template and `rlm-util` to get the licenses information from database and render it in the template.

**Why**
We need to be able to simulate the output from RLM to test the parser in the License Simulator project.

**Task:** https://app.clickup.com/t/1ufbgty