### PR TITLE
ARMADA-766 Move the API endpoints to a subapp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 This file keeps track of all notable changes to license-manager-simulator
 
 ## Unreleased
+* Move the API endpoints to a subapp in the URL http://<ip-address>:<port>/lm-sim
 
 ## 0.1.0 -- 2021-09-30
 * Created CLI app to produce simulated flexlm output (from data pulled from API)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 This file keeps track of all notable changes to license-manager-simulator
 
 ## Unreleased
+
+## 0.2.0 -- 2022-08-19
 * Move the API endpoints to a subapp in the URL http://<ip-address>:<port>/lm-sim
 
 ## 0.1.0 -- 2021-09-30

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ $ docker-compose up
 
 This will create a container for the API, and also a PostgreSQL container for the database.
 
-The API will be available at `http://localhost:8000`.
+The API will be available at `http://localhost:8000/lm-sim`.
 
 ## Prerequisites
 To use the license-manager-simulator you must have `Slurm` and `license-manager-agent` charms deployed with `Juju`.
@@ -82,13 +82,13 @@ To prepare your local `license-manager-agent` to use the simulator, run the simu
 pass it to the `make setup` command:
 
 ```bash
-$ make setup lm_sim_ip=http://127.0.0.1:8000
+$ make setup lm_sim_ip=http://127.0.0.1:8000/lm-sim
 ```
 
 After executing this command, you'll be able to submit jobs that use the simulated licenses.
 
 ## Usage
-You can add/remove licenses from the license server API using the online interface at `http://localhost:8000/docs`. This helps you to make requests directly with the browser into the API, with examples.
+You can add/remove licenses from the license server API using the online interface at `http://localhost:8000/lm-sim/docs`. This helps you to make requests directly with the browser into the API, with examples.
 
 There is an `application.sh` script that is intended to run in Slurm as a job that uses the licenses from the API. It is just a dummy
 application for testing purposes that creates a license_in_use in the API, sleeps, then deletes the license_in_use.

--- a/job/application.sh
+++ b/job/application.sh
@@ -4,8 +4,8 @@ set -e
 # You must modify this value to reflect the ip address and port that the
 # license-manager-simulator is listening on in your environment.
 #
-# The format of the value is: `http://<ip-address>:<port>`
-URL="http://localhost:8000"
+# The format of the value is: `http://<ip-address>:<port>/lm-sim`
+URL="http://localhost:8000/lm-sim"
 
 # number of licenses: from the CLI or 42
 if [ -z $1 ]; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "license-manager-simulator"
-version = "0.1.0"
+version = "0.2.0"
 description = "The license-manager-simulator is an application that simulates lmutil output for use in the development of applications which interface to the license servers."
 authors = ["OmniVector Solutions <info@omnivector.solutions>"]
 license = "MIT"

--- a/scripts/configure-licenses.sh
+++ b/scripts/configure-licenses.sh
@@ -12,7 +12,7 @@
 #
 # This script expects as argument:
 #   - IP address for License Manager Simulator API
-#		* format example: http://127.0.0.1:8000 
+#		* format example: http://127.0.0.1:8000/lm-sim 
 #
 # Note: The simulator API uses the `feature` to identify the licenses, as is done in the real license servers output.
 #       The `product` is used only in the backend config row and in the Slurm cluster.

--- a/scripts/copy-application.sh
+++ b/scripts/copy-application.sh
@@ -8,7 +8,7 @@
 #
 # This script expects as argument:
 #   - IP address for License Manager Simulator API
-#		* format example: http://127.0.0.1:8000 
+#		* format example: http://127.0.0.1:8000/lm-sim
 #
 # Note: To run the application you need to specify which license will be used in both the application and batch script files.
 #       For simplicity, this script will change the files to use 42 `abaqus` licenses.
@@ -25,7 +25,7 @@ fi
 
 # Change ip address in application file
 echo "Updating application file with simulator ip address"
-sed -i "s|http://localhost:8000|$lm_sim_ip|gi" ./job/application.sh
+sed -i "s|http://localhost:8000/lm-sim|$lm_sim_ip|gi" ./job/application.sh
 
 # Change license name to `abaqus` in job files
 echo "Updating job files with correct license name"

--- a/scripts/create-dev-setup.sh
+++ b/scripts/create-dev-setup.sh
@@ -11,7 +11,7 @@
 #
 # This script expects as argument:
 #   - IP address for License Manager Simulator API
-#		* format example: http://127.0.0.1:8000 
+#		* format example: http://127.0.0.1:8000/lm-sim 
 #
 # To run this script you need to have the simulator API running. Use `docker-compose up` to run the API.
 

--- a/scripts/prepare-environment.sh
+++ b/scripts/prepare-environment.sh
@@ -11,7 +11,7 @@
 #
 # This script expects as argument:
 #   - IP address for License Manager Simulator API
-#		* format example: http://127.0.0.1:8000 
+#		* format example: http://127.0.0.1:8000/lm-sim
 #
 # After preparing the environment, the licenses should be configured using the `configure-licenses.sh` script.
 
@@ -74,7 +74,7 @@ for i in {0..3}; do
 	echo "Updating ${folders[$i]}/${scripts[$i]} file"
 	sed -i "s|#!/usr/bin/env python3|$python_path|gi" ./bin/${folders[$i]}/${scripts[$i]}
 	sed -i "s|(\".\")|(\"$file_path\")|gi" ./bin/${folders[$i]}/${scripts[$i]}
-	sed -i "s|http://localhost:8000|$lm_sim_ip|gi" ./bin/${folders[$i]}/${scripts[$i]}
+	sed -i "s|http://localhost:8000/lm-sim|$lm_sim_ip|gi" ./bin/${folders[$i]}/${scripts[$i]}
 done
 
 # Copying script and template files to machine

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session
 
 from license_manager_simulator.config import settings
 from license_manager_simulator.database import Base
-from license_manager_simulator.main import app, get_db
+from license_manager_simulator.main import get_db, subapp
 from license_manager_simulator.schemas import LicenseCreate, LicenseInUseCreate
 
 
@@ -51,8 +51,8 @@ def client(session):
     def override_get_db():
         yield session
 
-    app.dependency_overrides[get_db] = override_get_db
-    yield TestClient(app)
+    subapp.dependency_overrides[get_db] = override_get_db
+    yield TestClient(subapp)
 
 
 @fixture

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,6 +4,12 @@ from fastapi import status
 from license_manager_simulator.models import License, LicenseInUse
 
 
+def test_health_check(client):
+    """Test the health check route."""
+    response = client.get("/health")
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+
+
 def test_create_license(client):
     """Test that the correct status code and response are returned on in use license creation."""
     response = client.post(


### PR DESCRIPTION
**What**

Move all endpoints of the License Manager Simulator API to a subapp at `http://<ip-address>:<port>/lm-sim`.
Also updates the tests, scripts, `README.md `and `CHANGELOG.md `after the subapp addition.

**Why**

All Armada APIs have subapps, but `license-manager-simulator` does not. 
This PR will change `license-manager-simulator` to run with a subapp, which is necessary to add a manifest for the `license-manager-simulator` to `armada-infrastructure`. 

Task: https://app.clickup.com/t/18022949/ARMADA-766