### PR TITLE
Change license name in the fake job application

### DIFF
--- a/job/application.sh
+++ b/job/application.sh
@@ -17,7 +17,7 @@ fi
 payload="{\"quantity\": "$X", \
           \"user_name\": \""$USER"\", \
           \"lead_host\": \"$(hostname)\", \
-          \"license_name\": \"fake_feature\"}"
+          \"license_name\": \"test_feature\"}"
 
 echo "Requesting $X licenses for user $USER"
 status=$(curl -s -o /dev/null -w '%{http_code}' \

--- a/job/batch.sh
+++ b/job/batch.sh
@@ -5,6 +5,6 @@
 #SBATCH --job-name=test
 #SBATCH --output=/tmp/%j.out
 #SBATCH --error=/tmp/%j.err
-#SBATCH --licenses=fake_license.fake_feature@flexlm:42
+#SBATCH --licenses=test_product.test_feature@flexlm:42
 
 srun /tmp/application.sh

--- a/license_manager_simulator/config.py
+++ b/license_manager_simulator/config.py
@@ -4,7 +4,7 @@ _DB_RX = r"^(sqlite|postgresql)://.+$"
 
 
 class Settings(BaseSettings):
-    DATABASE_URL: str = Field("sqlite:///./sqlite.db?check_same_thread=true", regex=_DB_RX)
+    DATABASE_URL: str = Field("sqlite:///./sqlite.db?check_same_thread=false", regex=_DB_RX)
 
     class Config:
         env_file = ".env"

--- a/scripts/configure-licenses.sh
+++ b/scripts/configure-licenses.sh
@@ -31,29 +31,17 @@ fi
 
 # Licenses to be added to the simulator API
 licenses_for_api=(
-    "abaqus"
-    "converge_super"
-    "MPPDYNA"
-    "HyperWorks"
-    "ftire_adams"
+    "test_feature"
 )
 
 # Licenses to be added to the Slurm cluster
 licenses_for_slurm=(
-    "abaqus.abaqus"
-    "converge.converge_super"
-    "mppdyna.mppdyna"
-    "hyperworks.hyperworks"
-    "cosin.ftire_adams"
+    "test_product.test_feature"
 )
 
 # Server type for Slurm licenses
 server_types=(
     "flexlm"
-    "rlm"
-    "lsdyna"
-    "lmx"
-    "olicense"
 )
 
 # Adding licenses to License Simulator API

--- a/scripts/copy-application.sh
+++ b/scripts/copy-application.sh
@@ -27,11 +27,6 @@ fi
 echo "Updating application file with simulator ip address"
 sed -i "s|http://localhost:8000|$lm_sim_ip|gi" ./job/application.sh
 
-# Change license name to `abaqus` in job files
-echo "Updating job files with correct license name"
-sed -i "s|fake_feature|abaqus|gi" ./job/application.sh
-sed -i "s|fake_license.fake_feature|abaqus.abaqus|gi" ./job/batch.sh
-
 # Copy batch and application files to slurmd node
 echo "Copying files to slurmd node"
 juju scp ./job/batch.sh slurmd/leader:/tmp


### PR DESCRIPTION
The name in the fake job was referencing a real license, which could lead to confusion.
Also removes the set up for real licenses and instead creates a fake one.